### PR TITLE
refactor: delete poll options only for listings with category polls i…

### DIFF
--- a/routes/cityListings.js
+++ b/routes/cityListings.js
@@ -777,8 +777,10 @@ router.delete("/:id", authentication, async function (req, res, next) {
                 { listingId: id },
                 cityId
             );
-            // delete poll options with listingId; id
-            await database.deleteData(tables.POLL_OPTIONS_TABLE, { listingId: id }, cityId);
+            // delete poll options with listingId: id
+            if (currentListingData.categoryId === categories.Polls) {
+                await database.deleteData(tables.POLL_OPTIONS_TABLE, { listingId: id }, cityId);
+            }
             await database.deleteData(tables.LISTINGS_TABLE, { id }, cityId);
             return res.status(200).json({
                 status: "success",


### PR DESCRIPTION
Projects lacking poll options are currently encountering a `"Table 'heidi_city_1.poll_options' doesn't exist"` error when attempting to delete from the `poll_options` table. This issue arises because the category ID 25 check is not performed before deletion. Implementing this check will mitigate the problem to some extent.