### PR TITLE
fix: Update default image count for Polls category

### DIFF
--- a/constants/defaultImagesInBucketCount.js
+++ b/constants/defaultImagesInBucketCount.js
@@ -38,7 +38,7 @@ if (process.env.APPLICATION === "WALDI") {
         EatOrDrink:1,
         AppointmentBooking:9,
         DefectReporter:6,
-        Polls:8,
+        Polls:1,
         Officialnotification: 1,
         Applicants:4
     };


### PR DESCRIPTION
Update default image count for Polls category to 1 