### PR TITLE
fix: update order by clause to handle null startDate in retrieveListings

### DIFF
--- a/v2/repository/listingsRepo.js
+++ b/v2/repository/listingsRepo.js
@@ -105,7 +105,7 @@ class ListingsRepo extends BaseRepo {
             }
         });
 
-        const orderByClause = sortByStartDate ? " ORDER BY L.startDate, L.createdAt DESC" : " ORDER BY L.createdAt DESC";
+        const orderByClause = sortByStartDate ? " ORDER BY COALESCE(L.startDate, L.createdAt) DESC" : " ORDER BY L.createdAt DESC";
         const paginationQuery = `${query} ${orderByClause} LIMIT ?, ?`;
         const offset = (pageNo - 1) * pageSize;
         queryParams.push(parseInt(offset, 10), parseInt(pageSize, 10));


### PR DESCRIPTION
These changes update order by clause to handle null startDate in retrieveListings to solve showing newly created listings at the top.